### PR TITLE
Fix SonarQube code coverage detection

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -99,7 +99,7 @@ jobs:
         --logger "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true"
         /p:CollectCoverage=true
         /p:CoverletOutputFormat=opencover
-        /p:CoverletOutput="./../../TestResults"
+        /p:CoverletOutput="./../../TestResults/coverage"
 
     - name: Upload dotnet test results
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -97,9 +97,7 @@ jobs:
         --logger trx
         --results-directory "./TestResults/"
         --logger "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true"
-        /p:CollectCoverage=true
-        /p:CoverletOutputFormat=opencover
-        /p:CoverletOutput="./../../TestResults/"
+        --collect:"XPlat Code Coverage"
 
     - name: Upload dotnet test results
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -104,7 +104,7 @@ jobs:
     - name: Upload dotnet test results
       uses: actions/upload-artifact@v4
       with:
-        name: TestResults
+        name: TestResults.zip
         path: ./TestResults/
       # Use always() to always run this step to publish test results when there are test failures
       if: ${{ always() }}
@@ -127,6 +127,6 @@ jobs:
     - name: Upload NuGet package artifact
       uses: actions/upload-artifact@v6
       with:
-        name: NuGetPackage
+        name: NuGetPackage.zip
         path: ./nupkg/*.nupkg
         retention-days: 3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -115,7 +115,7 @@ jobs:
       run: |
         .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
 
-    # --- NuGet Pack, Upload & Publish ---
+    # --- NuGet Pack + Upload ---
     - name: Pack NuGet package
       run: >
         dotnet pack ${{ env.solutionPath }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -98,7 +98,7 @@ jobs:
         --results-directory "./TestResults/"
         --logger "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true"
         /p:CollectCoverage=true
-        /p:CoverletOutputFormat=\"json,cobertura\"
+        /p:CoverletOutputFormat="json,cobertura"
         /p:CoverletOutput="./../../TestResults/"
         /p:MergeWith=./TestResults/coverage.json
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -97,7 +97,10 @@ jobs:
         --logger trx
         --results-directory "./TestResults/"
         --logger "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true"
-        --collect:"XPlat Code Coverage"
+        /p:CollectCoverage=true
+        /p:CoverletOutputFormat=\"json,cobertura\"
+        /p:CoverletOutput="./../../TestResults/"
+        /p:MergeWith=./TestResults/coverage.json
 
     - name: Upload dotnet test results
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -81,7 +81,7 @@ jobs:
         /d:sonar.host.url="https://sonarcloud.io"
         /v:"${{ env.GitVersion_FullSemVer }}"
         /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
-        /d:sonar.cs.opencover.reportsPaths=merged-coverage/opencover.xml
+        /d:sonar.cs.opencover.reportsPaths=./TestResults/coverage*.opencover.xml
 
     # --- Build ---
     - name: Build ${{ env.solutionPath }} ${{ env.GitVersion_FullSemVer }}
@@ -100,16 +100,6 @@ jobs:
         /p:CollectCoverage=true
         /p:CoverletOutputFormat="opencover"
         /p:CoverletOutput="./../../TestResults/coverage"
-
-    - name: Install ReportGenerator
-      run: dotnet tool install --global dotnet-reportgenerator-globaltool
-
-    - name: Merge coverage reports
-      run: >
-        reportgenerator
-        -reports:"TestResults/coverage*.opencover.xml"
-        -targetdir:"merged-coverage"
-        -reporttypes:opencover
 
     - name: Upload dotnet test results
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -81,7 +81,6 @@ jobs:
         /d:sonar.host.url="https://sonarcloud.io"
         /v:"${{ env.GitVersion_FullSemVer }}"
         /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
-        /d:sonar.cs.opencover.reportsPaths=./TestResults/coverage.opencover.xml
         /d:sonar.cs.opencover.reportsPaths=merged-coverage/opencover.xml
 
     # --- Build ---

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -98,8 +98,8 @@ jobs:
         --results-directory "./TestResults/"
         --logger "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true"
         /p:CollectCoverage=true
-        /p:CoverletOutputFormat="opencover"
-        /p:CoverletOutput="./../../TestResults/coverage"
+        /p:CoverletOutputFormat=opencover
+        /p:CoverletOutput="./../../TestResults"
 
     - name: Upload dotnet test results
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -82,6 +82,7 @@ jobs:
         /v:"${{ env.GitVersion_FullSemVer }}"
         /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
         /d:sonar.cs.opencover.reportsPaths=./TestResults/coverage.opencover.xml
+        /d:sonar.cs.opencover.reportsPaths=merged-coverage/opencover.xml
 
     # --- Build ---
     - name: Build ${{ env.solutionPath }} ${{ env.GitVersion_FullSemVer }}
@@ -98,9 +99,18 @@ jobs:
         --results-directory "./TestResults/"
         --logger "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true"
         /p:CollectCoverage=true
-        /p:CoverletOutputFormat="json,cobertura"
-        /p:CoverletOutput="./../../TestResults/"
-        /p:MergeWith=./TestResults/coverage.json
+        /p:CoverletOutputFormat="opencover"
+        /p:CoverletOutput="./../../TestResults/coverage"
+
+    - name: Install ReportGenerator
+      run: dotnet tool install --global dotnet-reportgenerator-globaltool
+
+    - name: Merge coverage reports
+      run: >
+        reportgenerator
+        -reports:"TestResults/coverage*.opencover.xml"
+        -targetdir:"merged-coverage"
+        -reporttypes:opencover
 
     - name: Upload dotnet test results
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Fix SonarQube code coverage detection

The code coverage reports were necessary to name with the
`CoverletOutput` parameter, otherwise files were generated starting with
`TestResults` whereby this is should be the directory and not part of
the code coverage report file name.
In addition, the SonarQube prepare step was updated to point SonarQube
to the correct coverage report files. Because this library is targets
multiple frameworks, each of its test runs creates a dedicated code
coverage report file, hence a wildcard (asterisk) was necessary to used
to tell SonarQube to fetch all of those files and merge them by itself.