### PR TITLE
Enable symbol package generation

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,8 @@
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Added `IncludeSymbols` and `SymbolPackageFormat` properties to `Directory.Build.props` to enable generation of `.snupkg` symbol packages for better debugging and NuGet symbol support.