### PR TITLE
Update README to include negative duration support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,8 +4,6 @@
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -1,40 +1,47 @@
 [![Build and analyze][1]][10]
 [![Quality Gate Status][2]][11]
+[![NuGet Version][3]][12]
 
 # DurationMancer
 
-DurationMancer is a simple library that provides a flexible time parser that understands both technical and natural language inputs. You can use these formats wherever a time duration is required, and you don't want to deal with the hassle of parsing strings yourself.
-
-ℹ️ Negative values are not supported (yet)!
+DurationMancer is a simple library that provides a flexible time parser that understands both technical and natural language inputs. You can use these formats wherever a (negative) time duration is required, and you don't want to deal with the hassle of parsing strings yourself.
 
 ## Supported Formats
 
 ### Standard Duration Format
 
-This format is best for precise, structured input. It follows the pattern: `[days.]HH:mm:ss[.milliseconds]`
+This format is best for precise, structured input.  
 
-| Component        | Format | Range / Description                               |
-|:-----------------|:-------|:--------------------------------------------------|
-| **Days**         | `d.`   | Optional. Any number of digits followed by a dot. |
-| **Hours**        | `HH`   | **Required.** 00 to 23.                           |
-| **Minutes**      | `mm`   | **Required.** 00 to 59.                           |
-| **Seconds**      | `ss`   | **Required.** 00 to 59.                           |
-| **Milliseconds** | `.fff` | Optional. Up to 3 digits following a dot.         |
+It follows the pattern:  
+`[-][days.]HH:mm:ss[.milliseconds]`
+
+| Component        | Format | Range / Description                                    |
+| :--------------- | :----- | :----------------------------------------------------- |
+| _Negative sign_  | `-`    | Optional. Defines that the value provided is negative. |
+| **Days**         | `d.`   | Optional. Any number of digits followed by a dot.      |
+| **Hours**        | `HH`   | **Required.** 00 to 23.                                |
+| **Minutes**      | `mm`   | **Required.** 00 to 59.                                |
+| **Seconds**      | `ss`   | **Required.** 00 to 59.                                |
+| **Milliseconds** | `.fff` | Optional. Up to 3 digits following a dot.              |
 
 **Examples:**
 
 - `12:30:00` → 12 hours, 30 minutes
 - `1.05:00:00` → 1 day, 5 hours
 - `00:00:45.500` → 45.5 seconds
+- `-00:00:05` → -5 seconds
 
 ### Human-Readable Format
 
-This format is ideal for quick CLI input. You can mix and match units using full names or shorthand.
+This format is ideal for quick CLI input. You can mix and match units using full names or shorthand.  
+
+ℹ️ Please note that a negative value is defined by a `minus` sign (`-`) in the first position of the entire string to be parse.
 
 #### Supported Units
 
 | Unit             | Keywords (Case-Insensitive)         |
-|:-----------------|:------------------------------------|
+| :--------------- | :---------------------------------- |
+| _Negative sign_  | `-`                                 |
 | **Days**         | `d`, `day`, `days`                  |
 | **Hours**        | `h`, `hour`, `hours`                |
 | **Minutes**      | `m`, `min`, `minute`, `minutes`     |
@@ -54,6 +61,8 @@ This format is ideal for quick CLI input. You can mix and match units using full
 - 1.5 hours → `01:30:00`
 - 100 ms → `00:00:00.100`
 - 2 days 4 h 15 m 30 s → `2.04:15:30`
+- -1m → `-00:01:00`
+- -1m 13s → `-00:01:13`
 
 ## Usage
 
@@ -99,8 +108,10 @@ For detailed benchmark results, please check the [Benchmarks page](https://githu
 
 [1]: https://github.com/HaGGi13/DurationMancer/actions/workflows/build.yaml/badge.svg
 [2]: https://sonarcloud.io/api/project_badges/measure?project=HaGGi13_DurationMancer&metric=alert_status
+[3]: https://img.shields.io/nuget/v/DurationMancer?style=flat&logo=nuget
 
 <!--# badge link references -->
 
 [10]: https://github.com/HaGGi13/DurationMancer/actions/workflows/build.yaml "Build pipeline"
 [11]: https://sonarcloud.io/summary/new_code?id=HaGGi13_DurationMancer "Latest new code analysis"
+[12]: https://www.nuget.org/packages/DurationMancer "NuGet: DurationMancer"

--- a/src/DurationMancer/DurationMancer.csproj
+++ b/src/DurationMancer/DurationMancer.csproj
@@ -7,10 +7,10 @@
 
     <PropertyGroup>
         <PackageId>DurationMancer</PackageId>
-        <Version>1.0.0</Version>
+        <Version>0.0.1</Version>
         <Authors>Christopher Wolf</Authors>
         <Description>
-            DurationMancer parses human‑readable time expressions like “7h 13m”, “1:45:00”, or “5 days 7min 13ms” into TimeSpan values. It supports flexible formats, abbreviations, and natural‑language‑style inputs.
+            DurationMancer parses human‑readable and standard format time expressions like "7h 13m" or "00:00:05" into TimeSpan values.
             It parses duration values only and does not extract them from full sentences or larger text.
         </Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/DurationMancer/DurationMancer.csproj
+++ b/src/DurationMancer/DurationMancer.csproj
@@ -1,6 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    </PropertyGroup>
+
+    <PropertyGroup>
         <PackageId>DurationMancer</PackageId>
         <Version>1.0.0</Version>
         <Authors>Christopher Wolf</Authors>

--- a/tests/DurationMancer.Tests/DurationTimeParserTests.Parse.cs
+++ b/tests/DurationMancer.Tests/DurationTimeParserTests.Parse.cs
@@ -121,6 +121,83 @@ public static partial class DurationTimeParserTests
 
         #endregion
 
+        #region Case insensitivity tests
+
+        [Theory]
+        [MemberData(nameof(DurationTimeParserValidTestData.ValidCaseInsensitiveInputs),
+            MemberType = typeof(DurationTimeParserValidTestData))]
+        public void Parse_CaseInsensitiveInput_ShouldParseCorrectly(string input, string result)
+        {
+            // Arrange
+            _ = TimeSpan.TryParse(result, out var expectedResult);
+
+            // Act
+            var parsedResult = DurationTimeParser.Parse(input);
+
+            // Assert
+            parsedResult.Should().Be(expectedResult);
+        }
+
+        #endregion
+
+        #region Whitespace-padded input tests
+
+        [Theory]
+        [MemberData(nameof(DurationTimeParserValidTestData.ValidWhitespacePaddedInputs),
+            MemberType = typeof(DurationTimeParserValidTestData))]
+        public void Parse_WhitespacePaddedInput_ShouldParseCorrectly(string input, string result)
+        {
+            // Arrange
+            _ = TimeSpan.TryParse(result, out var expectedResult);
+
+            // Act
+            var parsedResult = DurationTimeParser.Parse(input);
+
+            // Assert
+            parsedResult.Should().Be(expectedResult);
+        }
+
+        #endregion
+
+        #region Standalone fractional unit tests
+
+        [Theory]
+        [MemberData(nameof(DurationTimeParserValidTestData.ValidStandaloneFractionalUnitInputs),
+            MemberType = typeof(DurationTimeParserValidTestData))]
+        public void Parse_StandaloneFractionalUnit_ShouldParseCorrectly(string input, string result)
+        {
+            // Arrange
+            _ = TimeSpan.TryParse(result, out var expectedResult);
+
+            // Act
+            var parsedResult = DurationTimeParser.Parse(input);
+
+            // Assert
+            parsedResult.Should().Be(expectedResult);
+        }
+
+        #endregion
+
+        #region Boundary value tests
+
+        [Theory]
+        [MemberData(nameof(DurationTimeParserValidTestData.ValidBoundaryInputs),
+            MemberType = typeof(DurationTimeParserValidTestData))]
+        public void Parse_BoundaryValues_ShouldParseCorrectly(string input, int days, int hours, int minutes,
+            int seconds, int milliseconds)
+        {
+            // Arrange
+            var expected = new TimeSpan(days, hours, minutes, seconds, milliseconds);
+
+            // Act
+            var parsedResult = DurationTimeParser.Parse(input);
+
+            // Assert
+            parsedResult.Should().Be(expected);
+        }
+
+        #endregion
+
         #region Value rolling over tests that result in next bigger unit
 
         [Theory]
@@ -401,63 +478,6 @@ public static partial class DurationTimeParserTests
 
         #endregion
 
-#region Case insensitivity tests
-
-        [Theory]
-        [MemberData(nameof(DurationTimeParserValidTestData.ValidCaseInsensitiveInputs),
-            MemberType = typeof(DurationTimeParserValidTestData))]
-        public void Parse_CaseInsensitiveInput_ShouldParseCorrectly(string input, string result)
-        {
-            // Arrange
-            _ = TimeSpan.TryParse(result, out var expectedResult);
-
-            // Act
-            var parsedResult = DurationTimeParser.Parse(input);
-
-            // Assert
-            parsedResult.Should().Be(expectedResult);
-        }
-
-        #endregion
-
-        #region Whitespace-padded input tests
-
-        [Theory]
-        [MemberData(nameof(DurationTimeParserValidTestData.ValidWhitespacePaddedInputs),
-            MemberType = typeof(DurationTimeParserValidTestData))]
-        public void Parse_WhitespacePaddedInput_ShouldParseCorrectly(string input, string result)
-        {
-            // Arrange
-            _ = TimeSpan.TryParse(result, out var expectedResult);
-
-            // Act
-            var parsedResult = DurationTimeParser.Parse(input);
-
-            // Assert
-            parsedResult.Should().Be(expectedResult);
-        }
-
-        #endregion
-
-        #region Standalone fractional unit tests
-
-        [Theory]
-        [MemberData(nameof(DurationTimeParserValidTestData.ValidStandaloneFractionalUnitInputs),
-            MemberType = typeof(DurationTimeParserValidTestData))]
-        public void Parse_StandaloneFractionalUnit_ShouldParseCorrectly(string input, string result)
-        {
-            // Arrange
-            _ = TimeSpan.TryParse(result, out var expectedResult);
-
-            // Act
-            var parsedResult = DurationTimeParser.Parse(input);
-
-            // Assert
-            parsedResult.Should().Be(expectedResult);
-        }
-
-        #endregion
-
         #region Negative unrolling tests
 
         [Theory]
@@ -561,26 +581,6 @@ public static partial class DurationTimeParserTests
 
             // Assert
             parsedResult.Should().Be(expectedResult);
-        }
-
-        #endregion
-
-        #region Boundary value tests
-
-        [Theory]
-        [MemberData(nameof(DurationTimeParserValidTestData.ValidBoundaryInputs),
-            MemberType = typeof(DurationTimeParserValidTestData))]
-        public void Parse_BoundaryValues_ShouldParseCorrectly(string input, int days, int hours, int minutes,
-            int seconds, int milliseconds)
-        {
-            // Arrange
-            var expected = new TimeSpan(days, hours, minutes, seconds, milliseconds);
-
-            // Act
-            var parsedResult = DurationTimeParser.Parse(input);
-
-            // Assert
-            parsedResult.Should().Be(expected);
         }
 
         #endregion

--- a/tests/DurationMancer.Tests/DurationTimeParserTests.TryParse.cs
+++ b/tests/DurationMancer.Tests/DurationTimeParserTests.TryParse.cs
@@ -129,6 +129,88 @@ public static partial class DurationTimeParserTests
 
         #endregion
 
+
+        #region Case insensitivity tests
+
+        [Theory]
+        [MemberData(nameof(DurationTimeParserValidTestData.ValidCaseInsensitiveInputs),
+            MemberType = typeof(DurationTimeParserValidTestData))]
+        public void TryParse_CaseInsensitiveInput_ReturnsTrueAndCorrectTimeSpan(string input, string result)
+        {
+            // Arrange
+            _ = TimeSpan.TryParse(result, out var expectedResult);
+
+            // Act
+            var parsedResult = DurationTimeParser.TryParse(input, out var parsedValue);
+
+            // Assert
+            parsedValue.Should().Be(expectedResult);
+            parsedResult.Should().BeTrue();
+        }
+
+        #endregion
+
+        #region Whitespace-padded input tests
+
+        [Theory]
+        [MemberData(nameof(DurationTimeParserValidTestData.ValidWhitespacePaddedInputs),
+            MemberType = typeof(DurationTimeParserValidTestData))]
+        public void TryParse_WhitespacePaddedInput_ReturnsTrueAndCorrectTimeSpan(string input, string result)
+        {
+            // Arrange
+            _ = TimeSpan.TryParse(result, out var expectedResult);
+
+            // Act
+            var parsedResult = DurationTimeParser.TryParse(input, out var parsedValue);
+
+            // Assert
+            parsedValue.Should().Be(expectedResult);
+            parsedResult.Should().BeTrue();
+        }
+
+        #endregion
+
+        #region Standalone fractional unit tests
+
+        [Theory]
+        [MemberData(nameof(DurationTimeParserValidTestData.ValidStandaloneFractionalUnitInputs),
+            MemberType = typeof(DurationTimeParserValidTestData))]
+        public void TryParse_StandaloneFractionalUnit_ReturnsTrueAndCorrectTimeSpan(string input, string result)
+        {
+            // Arrange
+            _ = TimeSpan.TryParse(result, out var expectedResult);
+
+            // Act
+            var parsedResult = DurationTimeParser.TryParse(input, out var parsedValue);
+
+            // Assert
+            parsedValue.Should().Be(expectedResult);
+            parsedResult.Should().BeTrue();
+        }
+
+        #endregion
+
+        #region Boundary value tests
+
+        [Theory]
+        [MemberData(nameof(DurationTimeParserValidTestData.ValidBoundaryInputs),
+            MemberType = typeof(DurationTimeParserValidTestData))]
+        public void TryParse_BoundaryValues_ReturnsTrueAndCorrectTimeSpan(string input, int days, int hours, int minutes,
+            int seconds, int milliseconds)
+        {
+            // Arrange
+            var expected = new TimeSpan(days, hours, minutes, seconds, milliseconds);
+
+            // Act
+            var parsedResult = DurationTimeParser.TryParse(input, out var parsedValue);
+
+            // Assert
+            parsedValue.Should().Be(expected);
+            parsedResult.Should().BeTrue();
+        }
+
+        #endregion
+
         #region Value rolling over tests that result in next bigger unit
 
         [Theory]
@@ -428,67 +510,6 @@ public static partial class DurationTimeParserTests
 
         #endregion
 
-
-        #region Case insensitivity tests
-
-        [Theory]
-        [MemberData(nameof(DurationTimeParserValidTestData.ValidCaseInsensitiveInputs),
-            MemberType = typeof(DurationTimeParserValidTestData))]
-        public void TryParse_CaseInsensitiveInput_ReturnsTrueAndCorrectTimeSpan(string input, string result)
-        {
-            // Arrange
-            _ = TimeSpan.TryParse(result, out var expectedResult);
-
-            // Act
-            var parsedResult = DurationTimeParser.TryParse(input, out var parsedValue);
-
-            // Assert
-            parsedValue.Should().Be(expectedResult);
-            parsedResult.Should().BeTrue();
-        }
-
-        #endregion
-
-        #region Whitespace-padded input tests
-
-        [Theory]
-        [MemberData(nameof(DurationTimeParserValidTestData.ValidWhitespacePaddedInputs),
-            MemberType = typeof(DurationTimeParserValidTestData))]
-        public void TryParse_WhitespacePaddedInput_ReturnsTrueAndCorrectTimeSpan(string input, string result)
-        {
-            // Arrange
-            _ = TimeSpan.TryParse(result, out var expectedResult);
-
-            // Act
-            var parsedResult = DurationTimeParser.TryParse(input, out var parsedValue);
-
-            // Assert
-            parsedValue.Should().Be(expectedResult);
-            parsedResult.Should().BeTrue();
-        }
-
-        #endregion
-
-        #region Standalone fractional unit tests
-
-        [Theory]
-        [MemberData(nameof(DurationTimeParserValidTestData.ValidStandaloneFractionalUnitInputs),
-            MemberType = typeof(DurationTimeParserValidTestData))]
-        public void TryParse_StandaloneFractionalUnit_ReturnsTrueAndCorrectTimeSpan(string input, string result)
-        {
-            // Arrange
-            _ = TimeSpan.TryParse(result, out var expectedResult);
-
-            // Act
-            var parsedResult = DurationTimeParser.TryParse(input, out var parsedValue);
-
-            // Assert
-            parsedValue.Should().Be(expectedResult);
-            parsedResult.Should().BeTrue();
-        }
-
-        #endregion
-
         #region Negative unrolling tests
 
         [Theory]
@@ -530,7 +551,8 @@ public static partial class DurationTimeParserTests
         [Theory]
         [MemberData(nameof(DurationTimeParserRollingOverTestData.ValidNegativeRollingOver1001MillisecondsInputs),
             MemberType = typeof(DurationTimeParserRollingOverTestData))]
-        public void TryParse_NegativeRollingOverThousandAndOneMilliseconds_ReturnsTrueAndNegativeOneSecondAndOneMillisecond(string input)
+        public void TryParse_NegativeRollingOverThousandAndOneMilliseconds_ReturnsTrueAndNegativeOneSecondAndOneMillisecond(
+            string input)
         {
             // Arrange
             // Act
@@ -572,7 +594,8 @@ public static partial class DurationTimeParserTests
         [Theory]
         [MemberData(nameof(DurationTimeParserRollingOverTestData.ValidNegativeRollingOverWithNonZeroHigherComponentInputs),
             MemberType = typeof(DurationTimeParserRollingOverTestData))]
-        public void TryParse_NegativeRollingOverWithNonZeroHigherComponents_ReturnsTrueAndCorrectTimeSpan(string input, string result)
+        public void TryParse_NegativeRollingOverWithNonZeroHigherComponents_ReturnsTrueAndCorrectTimeSpan(string input,
+            string result)
         {
             // Arrange
             _ = TimeSpan.TryParse(result, out var expectedResult);
@@ -598,27 +621,6 @@ public static partial class DurationTimeParserTests
 
             // Assert
             parsedValue.Should().Be(expectedResult);
-            parsedResult.Should().BeTrue();
-        }
-
-        #endregion
-
-        #region Boundary value tests
-
-        [Theory]
-        [MemberData(nameof(DurationTimeParserValidTestData.ValidBoundaryInputs),
-            MemberType = typeof(DurationTimeParserValidTestData))]
-        public void TryParse_BoundaryValues_ReturnsTrueAndCorrectTimeSpan(string input, int days, int hours, int minutes,
-            int seconds, int milliseconds)
-        {
-            // Arrange
-            var expected = new TimeSpan(days, hours, minutes, seconds, milliseconds);
-
-            // Act
-            var parsedResult = DurationTimeParser.TryParse(input, out var parsedValue);
-
-            // Assert
-            parsedValue.Should().Be(expected);
             parsedResult.Should().BeTrue();
         }
 

--- a/tests/DurationMancer.Tests/TestData/DurationTimeParserInvalidTestData.cs
+++ b/tests/DurationMancer.Tests/TestData/DurationTimeParserInvalidTestData.cs
@@ -275,7 +275,7 @@ public sealed class DurationTimeParserInvalidTestData
 
         // Human-readable values that cause numeric parsing errors
         "-1E+999999999 days", // This value is too small for double.Parse and will throw OverflowException
-        "-999999999 days 23 hours 59 minutes 59 seconds", // This will cause TimeSpan overflow when components are added together
+        "-999999999 days 23 hours 59 minutes 59 seconds" // This will cause TimeSpan overflow when components are added together
     ];
 
     /// <summary>
@@ -330,6 +330,6 @@ public sealed class DurationTimeParserInvalidTestData
         "-1.2.3 days", // The double.Parse will throw FormatException due to multiple decimal points
 
         // Negative invalid double
-        "-1 day 2.5ms", // int.Parse will throw FormatException due to an invalid integer format
+        "-1 day 2.5ms" // int.Parse will throw FormatException due to an invalid integer format
     ];
 }

--- a/tests/DurationMancer.Tests/TestData/DurationTimeParserValidTestData.cs
+++ b/tests/DurationMancer.Tests/TestData/DurationTimeParserValidTestData.cs
@@ -278,7 +278,7 @@ public sealed class DurationTimeParserValidTestData
 
     /// <summary>
     /// Valid inputs with case-insensitive unit abbreviations (uppercase, mixed case).
-    /// The regex uses <see cref="System.Text.RegularExpressions.RegexOptions.IgnoreCase"/>,
+    /// The regex uses <see cref="System.Text.RegularExpressions.RegexOptions.IgnoreCase" />,
     /// so these should all parse correctly.
     /// </summary>
     public static TheoryData<string, string> ValidCaseInsensitiveInputs => new()
@@ -397,7 +397,7 @@ public sealed class DurationTimeParserValidTestData
     };
 
     /// <summary>
-    /// Valid inputs near the <see cref="TimeSpan.MaxValue"/> and <see cref="TimeSpan.MinValue"/> boundaries.
+    /// Valid inputs near the <see cref="TimeSpan.MaxValue" /> and <see cref="TimeSpan.MinValue" /> boundaries.
     /// </summary>
     public static TheoryData<string, int, int, int, int, int> ValidBoundaryInputs => new()
     {


### PR DESCRIPTION
Expanded the documentation to cover negative duration inputs for both formats, updated examples, and added a badge for the current NuGet version.

In addition the symbol package configuration was set to project level to not apply it to all other projects within the repository.

The package metadata were slightly modified for simplicity.

The whole test project was auto-formatted to align previous add code of PR #14.